### PR TITLE
Ahaggett activity rings api

### DIFF
--- a/src/Controller/PathwaysController.php
+++ b/src/Controller/PathwaysController.php
@@ -386,11 +386,14 @@ class PathwaysController extends AppController
                     array($listenpercent,$listenpercentleft,$listencolor),
                     array($participatepercent,$participatepercentleft,$participatecolor)
             );
-            
+            $status = 'In progress';
+            if($readpercent == 100 && $watchpercent == 100 && $listenpercent == 100 && $participatepercent == 100) {
+                $status = 'Completed!';
+            }            
             if(!empty($user)) {
 
                 
-                $this->set(compact('percentages'));
+                $this->set(compact(['percentages','status']));
                 
             
             } else {

--- a/src/Controller/PathwaysController.php
+++ b/src/Controller/PathwaysController.php
@@ -391,7 +391,7 @@ class PathwaysController extends AppController
             );
             
             $status = 'In progress ' . $overallp . '%';
-            if($readpercent == 100 && $watchpercent == 100 && $listenpercent == 100 && $participatepercent == 100) {
+            if($overallp == 100) {
                 $status = 'Completed!';
                 // #TODO check against current pathways_users status in db and 
                 // write a method to update the pathways_users status if it doesn't match

--- a/src/Controller/PathwaysController.php
+++ b/src/Controller/PathwaysController.php
@@ -178,4 +178,194 @@ class PathwaysController extends AppController
 
         return $this->redirect(['action' => 'index']);
     }
+
+
+
+       /**
+     * View method
+     *
+     * @param string|null $id Pathway id.
+     * @return \Cake\Http\Response|null
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function status($id = null)
+    {
+        $this->Authorization->skipAuthorization();
+        // As we loop through the activities for the steps on this pathway, we 
+        // need to be able to check to see if the current user has "claimed" 
+        // that activity. Here we get the current user id and use it to select 
+        // all of the claimed activities assigned to them, and then process out 
+        // just the activity IDs into a simple array. Then, in the template 
+        // code, we can simply  if(in_array($rj->activity->id,$useractivitylist
+        //
+        // First let's check to see if this person is logged in or not.
+        //
+	    $user = $this->request->getAttribute('authentication')->getIdentity();
+        if(!empty($user)) {
+            // We need create an empty array first. If nothing gets added to
+            // it, so be it
+            $useractivitylist = array();
+            // Get access to the apprprioate table
+            $au = TableRegistry::getTableLocator()->get('ActivitiesUsers');
+            // Select based on currently logged in person
+            $useacts = $au->find()->where(['user_id = ' => $user->id]);
+            // convert the results into a simple array so that we can
+            // use in_array in the template
+            $useractivities = $useacts->toList();
+            // Loop through the resources and add just the ID to the 
+            // array that we will pass into the template
+            foreach($useractivities as $uact) {
+                array_push($useractivitylist, $uact['activity_id']);
+            }
+        }
+
+        $pathway = $this->Pathways->get($id, [
+            'contain' => ['Categories', 'Ministries', 'Competencies', 'Steps', 'Steps.Activities', 'Steps.Activities.ActivityTypes', 'Steps.Activities.Users', 'Steps.Activities.Tags', 'Users'],
+        ]);
+    //
+	// we want to be able to tell if the current user is already on this
+	// pathway or not, so we take the same approach as above, parsing all
+	// the users into a single array so that we can perform a simple
+	// in_array($thisuser,$usersonthispathway) check and show the "take
+	// this Pathway" button or "you're on this Pathway" text
+	//
+	// Create the initially empty array that we also pass into the template
+	$usersonthispathway = array();
+	// Loop through the users that are on this pathway and parse just the 
+	// IDs into the array that we just created
+	foreach($pathway->users as $pu) {
+		array_push($usersonthispathway,$pu->id);
+	}
+
+
+    if (!empty($pathway->steps)) :
+    $totalActivities = 0;
+    $totalTime = 0;
+    $claimedcount = 0;
+    $readclaim = 0;
+    $watchclaim = 0;
+    $listenclaim = 0;
+    $participateclaim = 0;
+    $readtimetotal = 0;
+    $watchtimetotal = 0;
+    $listentimetotal = 0;
+    $participatetimetotal = 0;
+    
+    
+    $readtotal = array();
+    $watchtotal = array();
+    $listentotal = array();
+    $participatetotal = array();
+    
+    foreach ($pathway->steps as $steps) :
+    
+    $stepTime = 0;
+    $stepActivityCount = 0;
+    $readtime = 0;
+    $watchtime = 0;
+    $listentime = 0;
+    $participatetime = 0;
+    
+    $defunctacts = array();
+    $requiredacts = array();
+    $tertiaryacts = array();
+    
+    $readcount = array();
+    $watchcount = array();
+    $listencount = array();
+    $participatecount = array();
+    
+    $act = array();
+    foreach ($steps->activities as $activity) {
+        // If this is 'defunct' then we pull it out of the list 
+        if($activity->status_id == 2) {
+            array_push($defunctacts,$activity);
+        } else {
+            // if it's required
+            if($activity->_joinData->required == 1) {
+                array_push($requiredacts,$activity);
+            // Otherwise it's teriary
+            } else {
+                array_push($tertiaryacts,$activity);
+            }
+            //
+            // we want to count each type on a per step basis
+            // as well as adding to the total
+            //
+            if($activity->activity_type->name == 'Read') {
+                $readcolor = $activity->activity_type->color;
+                $readicon = $activity->activity_type->image_path;
+                array_push($readcount,$activity);
+                array_push($readtotal,$activity);
+                if(in_array($activity->id,$useractivitylist)) {
+                    $readclaim++;
+                }
+            } elseif($activity->activity_type->name == 'Watch') {
+                $watchcolor = $activity->activity_type->color;
+                $watchicon = $activity->activity_type->image_path;
+                array_push($watchcount,$activity);
+                array_push($watchtotal,$activity);
+                if(in_array($activity->id,$useractivitylist)) {
+                    $watchclaim++;
+                }
+            } elseif($activity->activity_type->name == 'Listen') {
+                $listencolor = $activity->activity_type->color;
+                $listenicon = $activity->activity_type->image_path;
+                array_push($listencount,$activity);
+                array_push($listentotal,$activity);
+                if(in_array($activity->id,$useractivitylist)) {
+                    $listenclaim++;
+                }
+            } elseif($activity->activity_type->name == 'Participate') {
+                $participatecolor = $activity->activity_type->color;
+                $participateicon = $activity->activity_type->image_path;
+                array_push($participatecount,$activity);
+                array_push($participatetotal,$activity);
+                if(in_array($activity->id,$useractivitylist)) {
+                    $participateclaim++;
+                }
+            }
+            $totalActivities++;
+            $stepTime = $stepTime + $activity->hours;
+            $totalTime = $totalTime + $activity->hours;
+            $stepActivityCount++;
+        }
+    }
+    
+    endforeach;
+    endif;
+    
+    $readp = ceil((count($readcount) / $stepActivityCount) * 100);
+    $watchp = ceil((count($watchcount) / $stepActivityCount) * 100);
+    $listenp = ceil((count($listencount) / $stepActivityCount) * 100);
+    $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
+    
+    
+    $readpercent = floor($readclaim / count($readtotal) * 100);
+    $readpercentleft = 100 - $readpercent;
+    $watchpercent = floor($watchclaim / count($watchtotal) * 100);
+    $watchpercentleft = 100 - $watchpercent;
+    $listenpercent = floor($listenclaim / count($listentotal) * 100);
+    $listenpercentleft = 100 - $listenpercent;
+    $participatepercent = floor($participateclaim / count($participatetotal) * 100);
+    $participatepercentleft = 100 - $participatepercent;
+    $percentages = array(
+            array($readpercent,$readpercentleft,$readcolor),
+            array($watchpercent,$watchpercentleft,$watchcolor),
+            array($listenpercent,$listenpercentleft,$listencolor),
+            array($participatepercent,$participatepercentleft,$participatecolor)
+    );
+    
+    if(!empty($user)) {
+		$this->set(compact('percentages'));
+	} else {
+		return $this->redirect(['controller' => 'Users', 'action' => 'login']);
+	}
+
+
+
+    }
+
+
+
 }

--- a/src/Controller/PathwaysController.php
+++ b/src/Controller/PathwaysController.php
@@ -272,7 +272,8 @@ class PathwaysController extends AppController
             $participatetotal = array();
             
             foreach ($pathway->steps as $steps) :
-            
+
+                
                 $stepTime = 0;
                 $stepActivityCount = 0;
                 $readtime = 0;
@@ -346,6 +347,7 @@ class PathwaysController extends AppController
                 endforeach; // activities
             endforeach; // steps
 
+            $overallp = ceil(((count($readcount) + count($watchcount) + count($listencount) + count($participatecount)) / $totalActivities) * 100);
             $readp = ceil((count($readcount) / $stepActivityCount) * 100);
             $watchp = ceil((count($watchcount) / $stepActivityCount) * 100);
             $listenp = ceil((count($listencount) / $stepActivityCount) * 100);
@@ -386,9 +388,11 @@ class PathwaysController extends AppController
                     array($listenpercent,$listenpercentleft,$listencolor),
                     array($participatepercent,$participatepercentleft,$participatecolor)
             );
-            $status = 'In progress';
+            $status = 'In progress ' . $overallp . '%';
             if($readpercent == 100 && $watchpercent == 100 && $listenpercent == 100 && $participatepercent == 100) {
                 $status = 'Completed!';
+                // #TODO check against current pathways_users status in db and 
+                // write a method to update the pathways_users status if it doesn't match
             }            
             if(!empty($user)) {
 

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -178,7 +178,12 @@ public function beforeFilter(\Cake\Event\EventInterface $event)
 
 	    $u = $this->request->getAttribute('authentication')->getIdentity();
         $user = $this->Users->get($u->id, [
-            'contain' => ['Pathways', 'Pathways.Categories', 'Activities', 'Activities.ActivityTypes','Competencies','Ministries'],
+            'contain' => ['Pathways', 
+                            'Pathways.Categories', 
+                            'Activities', 
+                            'Activities.ActivityTypes',
+                            'Competencies',
+                            'Ministries'],
         ]);
         $this->Authorization->authorize($user);
         $this->set('user', $user);

--- a/templates/Pathways/status.php
+++ b/templates/Pathways/status.php
@@ -1,0 +1,5 @@
+<?php 
+foreach ($percentages as &$p) {
+    unset($p);
+}
+echo json_encode(compact('percentages'));

--- a/templates/Pathways/status.php
+++ b/templates/Pathways/status.php
@@ -3,4 +3,4 @@
 foreach ($percentages as &$p) {
     unset($p);
 }
-echo json_encode(compact(['percentages','status']));
+echo json_encode(compact(['percentages','status','chartjs']));

--- a/templates/Pathways/status.php
+++ b/templates/Pathways/status.php
@@ -1,4 +1,5 @@
 <?php 
+
 foreach ($percentages as &$p) {
     unset($p);
 }

--- a/templates/Pathways/status.php
+++ b/templates/Pathways/status.php
@@ -3,4 +3,4 @@
 foreach ($percentages as &$p) {
     unset($p);
 }
-echo json_encode(compact('percentages'));
+echo json_encode(compact(['percentages','status']));

--- a/templates/Pathways/view.php
+++ b/templates/Pathways/view.php
@@ -403,13 +403,13 @@ $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
 			<i class="fas fa-exclamation-triangle"></i>
 		</a>	
 		<a href="/activities/like/<?= h($activity->id) ?>" style="color:#333;" class="likingit btn btn-light float-left mr-1" data-toggle="tooltip" data-placement="bottom" title="Like this activity">
-		<span class="lcount"><?= h($activity->recommended) ?></span> <i class="fas fa-thumbs-up"></i>
+			<span class="lcount"><?= h($activity->recommended) ?></span> <i class="fas fa-thumbs-up"></i>
 		</a>
 	<?php if(!empty($uid)): ?>
 	<?php if(!in_array($activity->id,$useractivitylist)): ?>
-	<?= $this->Form->create(null, ['url' => ['controller' => 'activities-users','action' => 'claim'], 'class' => '']) ?>
+	<?= $this->Form->create(null, ['url' => ['controller' => 'activities-users','action' => 'claim'], 'class' => 'claim']) ?>
 	<?= $this->Form->control('activity_id',['type' => 'hidden', 'value' => $activity->id]) ?>
-	<?= $this->Form->button(__('Claim'),['class'=>'btn btn-light claim', 'title' => 'You\'ve completed it, now claim it so it shows up on your profile', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom']) ?>
+	<?= $this->Form->button(__('Claim'),['class'=>'btn btn-light', 'title' => 'You\'ve completed it, now claim it so it shows up on your profile', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom']) ?>
 	<?= $this->Form->end() ?>
 	<?php else: ?>
 	<?php
@@ -540,14 +540,14 @@ $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
 	<a href="#" style="color:#333;" class="btn btn-light float-right" data-toggle="tooltip" data-placement="bottom" title="Report this activity for some reason">
 		<i class="fas fa-exclamation-triangle"></i>
 	</a>	
-		<a href="/activities/like/<?= h($activity->id) ?>" style="color:#333;" class="likingit btn btn-light float-left mr-1" data-toggle="tooltip" data-placement="bottom" title="Like this activity">
+	<a href="/activities/like/<?= h($activity->id) ?>" style="color:#333;" class="likingit btn btn-light float-left mr-1" data-toggle="tooltip" data-placement="bottom" title="Like this activity">
 		<span class="lcount"><?= h($activity->recommended) ?></span> <i class="fas fa-thumbs-up"></i>
-		</a>
+	</a>
 	<?php if(!empty($uid)): ?>
 	<?php if(!in_array($activity->id,$useractivitylist)): ?>
-	<?= $this->Form->create(null, ['url' => ['controller' => 'activities-users','action' => 'claim'], 'class' => '']) ?>
+	<?= $this->Form->create(null, ['url' => ['controller' => 'activities-users','action' => 'claim'], 'class' => 'claim']) ?>
 	<?= $this->Form->control('activity_id',['type' => 'hidden', 'value' => $activity->id]) ?>
-	<?= $this->Form->button(__('Claim'),['class'=>'btn btn-light claim', 'title' => 'You\'ve completed it, now claim it so it shows up on your profile', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom']) ?>
+	<?= $this->Form->button(__('Claim'),['class'=>'btn btn-light', 'title' => 'You\'ve completed it, now claim it so it shows up on your profile', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom']) ?>
 	<?= $this->Form->end() ?>
 	<?php else: ?>
 	<?php
@@ -774,11 +774,38 @@ $percentages = array(
 ?>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
 <script>
+
 loadStatus();
+
 var claim = document.querySelector('.claim');
-claim.addEventListener('click', function(e) {
+claim.addEventListener('submit', function(e) {
+
 	e.preventDefault();
-	loadStatus();
+
+	const params = serialize(claim);
+
+	// Create new Ajax request
+	const req = new XMLHttpRequest();
+	req.open('POST', claim.action, true);
+	req.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+
+	// Handle the events
+	req.onload = function() {
+		if (req.status >= 200 && req.status < 400) {
+			//console.log(req.responseText);
+			claim.innerHTML = '<span class="btn btn-dark">Claimed <i class="fas fa-check-circle"></i></span>';
+			$('body').tooltip('dispose');
+			loadStatus();
+		}
+	};
+	req.onerror = function() {
+		reject();
+	};
+
+	// Send it
+	req.send(params);
+	
+	
 
 
 });
@@ -820,7 +847,50 @@ function loadStatus() {
 }
 
 
-	
+const serialize = function(formEle) {
+    // Get all fields
+    const fields = [].slice.call(formEle.elements, 0);
+
+    return fields
+        .map(function(ele) {
+            const name = ele.name;
+            const type = ele.type;
+            
+            // We ignore
+            // - field that doesn't have a name
+            // - disabled field
+            // - `file` input
+            // - unselected checkbox/radio
+            if (!name ||
+                ele.disabled ||
+                type === 'file' ||
+                (/(checkbox|radio)/.test(type) && !ele.checked))
+            {
+                return '';
+            }
+
+            // Multiple select
+            if (type === 'select-multiple') {
+                return ele.options
+                    .map(function(opt) {
+                        return opt.selected
+                            ? `${encodeURIComponent(name)}=${encodeURIComponent(opt.value)}`
+                            : '';
+                    })
+                    .filter(function(item) {
+                        return item;
+                    })
+                    .join('&');
+            }
+
+            return `${encodeURIComponent(name)}=${encodeURIComponent(ele.value)}`;
+        })
+        .filter(function(item) {
+            return item;
+        })
+        .join('&');
+};
+
 </script>
 
 

--- a/templates/Pathways/view.php
+++ b/templates/Pathways/view.php
@@ -176,6 +176,11 @@ $watchcount = array();
 $listencount = array();
 $participatecount = array();
 
+$readcolor = '255,255,255';
+$watchcolor = '255,255,255';
+$listencolor = '255,255,255';
+$participatecolor = '255,255,255';
+
 $act = array();
 foreach ($steps->activities as $activity) {
 	// If this is 'defunct' then we pull it out of the list 
@@ -630,7 +635,7 @@ $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
 <?php if(!empty($uid)): ?>
 <?php if(in_array($uid,$usersonthispathway)): ?>
 
-<h1 class="mb-3">You're following this pathway!</h1>
+<h1 class="mb-3 following">You're following this pathway!</h1>
 
 
 
@@ -727,14 +732,35 @@ $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
 </div>
 </div>
 <?php
-$readpercent = floor($readclaim / count($readtotal) * 100);
-$readpercentleft = 100 - $readpercent;
-$watchpercent = floor($watchclaim / count($watchtotal) * 100);
-$watchpercentleft = 100 - $watchpercent;
-$listenpercent = floor($listenclaim / count($listentotal) * 100);
-$listenpercentleft = 100 - $listenpercent;
-$participatepercent = floor($participateclaim / count($participatetotal) * 100);
-$participatepercentleft = 100 - $participatepercent;
+
+if(!empty($readclaim) && count($readtotal) > 0) {
+	$readpercent = floor($readclaim / count($readtotal) * 100);
+	$readpercentleft = 100 - $readpercent;
+} else {
+	$readpercent = 0;
+	$readpercentleft = 100;       
+}
+if(!empty($watchclaim) && count($watchtotal) > 0) {
+	$watchpercent = floor($watchclaim / count($watchtotal) * 100);
+	$watchpercentleft = 100 - $watchpercent;
+} else {
+	$watchpercent = 0;
+	$watchpercentleft = 100;
+}
+if(!empty($listenclaim) && count($listentotal) > 0) {
+	$listenpercent = floor($listenclaim / count($listentotal) * 100);
+	$listenpercentleft = 100 - $listenpercent;
+} else {
+	$listenpercent = 0;
+	$listenpercentleft = 100;
+}
+if(!empty($participateclaim) && count($participatetotal) > 0) {
+	$participatepercent = floor($participateclaim / count($participatetotal) * 100);
+	$participatepercentleft = 100 - $participatepercent;
+} else {
+	$participatepercent = 0;
+	$participatepercentleft = 100;
+}
 $percentages = array(
         array($readpercent,$readpercentleft,$readcolor),
         array($watchpercent,$watchpercentleft,$watchcolor),
@@ -744,7 +770,8 @@ $percentages = array(
 ?>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
 <script>
-// Start by getting the summary for this pathway independently of the page load
+//
+// Get the summary for this pathway independently of the page load
 //
 var request = new XMLHttpRequest();
 request.open('GET', '/pathways/status/<?= $pathway->id ?>', true);
@@ -753,7 +780,8 @@ request.onload = function() {
   if (this.status >= 200 && this.status < 400) {
     // Success!
     var data = JSON.parse(this.response);
-	console.log(data.percentages);
+	document.querySelector('.following').innerHTML = data.status;
+	console.log(data);
   } else {
     // We reached our target server, but it returned an error
 

--- a/templates/Pathways/view.php
+++ b/templates/Pathways/view.php
@@ -409,7 +409,7 @@ $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
 	<?php if(!in_array($activity->id,$useractivitylist)): ?>
 	<?= $this->Form->create(null, ['url' => ['controller' => 'activities-users','action' => 'claim'], 'class' => '']) ?>
 	<?= $this->Form->control('activity_id',['type' => 'hidden', 'value' => $activity->id]) ?>
-	<?= $this->Form->button(__('Claim'),['class'=>'btn btn-light', 'title' => 'You\'ve completed it, now claim it so it shows up on your profile', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom']) ?>
+	<?= $this->Form->button(__('Claim'),['class'=>'btn btn-light claim', 'title' => 'You\'ve completed it, now claim it so it shows up on your profile', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom']) ?>
 	<?= $this->Form->end() ?>
 	<?php else: ?>
 	<?php
@@ -547,7 +547,7 @@ $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
 	<?php if(!in_array($activity->id,$useractivitylist)): ?>
 	<?= $this->Form->create(null, ['url' => ['controller' => 'activities-users','action' => 'claim'], 'class' => '']) ?>
 	<?= $this->Form->control('activity_id',['type' => 'hidden', 'value' => $activity->id]) ?>
-	<?= $this->Form->button(__('Claim'),['class'=>'btn btn-light', 'title' => 'You\'ve completed it, now claim it so it shows up on your profile', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom']) ?>
+	<?= $this->Form->button(__('Claim'),['class'=>'btn btn-light claim', 'title' => 'You\'ve completed it, now claim it so it shows up on your profile', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom']) ?>
 	<?= $this->Form->end() ?>
 	<?php else: ?>
 	<?php
@@ -774,39 +774,50 @@ $percentages = array(
 ?>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
 <script>
+loadStatus();
+var claim = document.querySelector('.claim');
+claim.addEventListener('click', function(e) {
+	e.preventDefault();
+	loadStatus();
+
+
+});
+
 //
 // Get the summary for this pathway independently of the page load
 //
-var request = new XMLHttpRequest();
-request.open('GET', '/pathways/status/<?= $pathway->id ?>', true);
+function loadStatus() {
 
-request.onload = function() {
-  if (this.status >= 200 && this.status < 400) {
-    // Success!
-    var chartdata = JSON.parse(this.response);
-	document.querySelector('.following').innerHTML = chartdata.status;
-	var ctx = document.getElementById('myChart').getContext('2d');
-	var myDoughnutChart = new Chart(ctx, {
-		type: 'doughnut',
-		data: JSON.parse(chartdata.chartjs),
-		options: { 
-			legend: { 
-				display: false 
-			},
-		}
-	});
+	var request = new XMLHttpRequest();
+	request.open('GET', '/pathways/status/<?= $pathway->id ?>', true);
 
-  } else {
-    // We reached our target server, but it returned an error
+	request.onload = function() {
+	if (this.status >= 200 && this.status < 400) {
+		// Success!
+		var chartdata = JSON.parse(this.response);
+		document.querySelector('.following').innerHTML = chartdata.status;
+		var ctx = document.getElementById('myChart').getContext('2d');
+		var myDoughnutChart = new Chart(ctx, {
+			type: 'doughnut',
+			data: JSON.parse(chartdata.chartjs),
+			options: { 
+				legend: { 
+					display: false 
+				},
+			}
+		});
 
-  }
-};
-request.onerror = function() {
-  // There was a connection error of some sort
-};
-request.send();
+	} else {
+		// We reached our target server, but it returned an error
 
+	}
+	};
+	request.onerror = function() {
+	// There was a connection error of some sort
+	};
+	request.send();
 
+}
 
 
 	

--- a/templates/Pathways/view.php
+++ b/templates/Pathways/view.php
@@ -5,9 +5,9 @@
  */
 
 $this->loadHelper('Authentication.Identity');
-if ($this->Identity->isLoggedIn()) {
-	$name = $this->Identity->get('role_id');
-}
+//if ($this->Identity->isLoggedIn()) {
+//	$name = $this->Identity->get('role_id');
+//}
 $uid = 0;
 $role = 0;
 if(!empty($active)) {

--- a/templates/Pathways/view.php
+++ b/templates/Pathways/view.php
@@ -14,6 +14,10 @@ if(!empty($active)) {
 	$role = $active->role_id;
 	$uid = $active->id;
 }
+
+
+
+
 ?>
 
 
@@ -779,9 +783,19 @@ request.open('GET', '/pathways/status/<?= $pathway->id ?>', true);
 request.onload = function() {
   if (this.status >= 200 && this.status < 400) {
     // Success!
-    var data = JSON.parse(this.response);
-	document.querySelector('.following').innerHTML = data.status;
-	console.log(data);
+    var chartdata = JSON.parse(this.response);
+	document.querySelector('.following').innerHTML = chartdata.status;
+	var ctx = document.getElementById('myChart').getContext('2d');
+	var myDoughnutChart = new Chart(ctx, {
+		type: 'doughnut',
+		data: JSON.parse(chartdata.chartjs),
+		options: { 
+			legend: { 
+				display: false 
+			},
+		}
+	});
+
   } else {
     // We reached our target server, but it returned an error
 
@@ -792,30 +806,7 @@ request.onerror = function() {
 };
 request.send();
 
-var ctx = document.getElementById('myChart').getContext('2d');
-var data = {
-    datasets: [
-<?php foreach($percentages as $ring): ?>
-{
-	data: [<?= $ring[0] ?>,<?= $ring[1] ?>],
-	labels: ['all the same','not all'],
-	'backgroundColor': ['rgba(<?= $ring[2] ?>,1)','rgba(<?= $ring[2] ?>,.2)']
-},
-<?php endforeach ?>
-],
 
-	labels: ['Percent done','Percent left']
-};
-
-var myDoughnutChart = new Chart(ctx, {
-    type: 'doughnut',
-    data: data,
-    options: { 
-        legend: { 
-            display: false 
-        },
-    }
-});
 
 
 	

--- a/templates/Pathways/view.php
+++ b/templates/Pathways/view.php
@@ -562,6 +562,7 @@ $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
 	}
 	?>
 	<div class="btn btn-light" data-toggle="tooltip" data-placement="bottom" title="You have completed this activity. Great work!">CLAIMED <i class="fas fa-check-circle"></i></div>
+
 	<?php endif ?>
 	<?php endif ?>
 
@@ -772,6 +773,14 @@ $percentages = array(
         array($participatepercent,$participatepercentleft,$participatecolor),
 );
 ?>
+<script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" 
+	integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" 
+	crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.0/js/bootstrap.min.js" 
+	integrity="sha384-3qaqj0lc6sV/qpzrc1N5DC6i1VRn/HyX4qdPaiEFbn54VjQBEU341pvjz7Dv3n6P" 
+	crossorigin="anonymous"></script>
+<script type="text/javascript" src="/js/bootstrap-multiselect.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
 <script>
 
@@ -793,8 +802,9 @@ claim.addEventListener('submit', function(e) {
 	req.onload = function() {
 		if (req.status >= 200 && req.status < 400) {
 			//console.log(req.responseText);
-			claim.innerHTML = '<span class="btn btn-dark">Claimed <i class="fas fa-check-circle"></i></span>';
 			$('body').tooltip('dispose');
+			claim.innerHTML = '<button class="btn btn-dark">Claimed <i class="fas fa-check-circle"></i></button>';
+			
 			loadStatus();
 		}
 	};

--- a/templates/Pathways/view.php
+++ b/templates/Pathways/view.php
@@ -15,6 +15,9 @@ if(!empty($active)) {
 	$uid = $active->id;
 }
 ?>
+
+
+
 <style>
 @media (min-width: 34em) {
     .card-columns {
@@ -191,6 +194,8 @@ foreach ($steps->activities as $activity) {
 		if($activity->activity_type->name == 'Read') {
 			$readcolor = $activity->activity_type->color;
 			$readicon = $activity->activity_type->image_path;
+			// #TODO probably shouldn't push the whole object onto
+			// the array when a simple +1 would do, but ...
 			array_push($readcount,$activity);
 			array_push($readtotal,$activity);
 		} elseif($activity->activity_type->name == 'Watch') {
@@ -739,10 +744,8 @@ $percentages = array(
 ?>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
 <script>
-
-
-
-
+// Start by getting the summary for this pathway independently of the page load
+//
 var request = new XMLHttpRequest();
 request.open('GET', '/pathways/status/<?= $pathway->id ?>', true);
 
@@ -756,12 +759,10 @@ request.onload = function() {
 
   }
 };
-
 request.onerror = function() {
   // There was a connection error of some sort
 };
 request.send();
-
 
 var ctx = document.getElementById('myChart').getContext('2d');
 var data = {

--- a/templates/Pathways/view.php
+++ b/templates/Pathways/view.php
@@ -341,7 +341,7 @@ $pp = ceil((count($participatecount) / $stepActivityCount) * 100);
 			height="315" 
 			src="https://www.youtube.com/embed/<?= h($activity->hyperlink) ?>/" 
 			frameborder="0" 
-			allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" 
+			allow="" 
 			allowfullscreen>
 		</iframe>
 	</div>
@@ -739,6 +739,30 @@ $percentages = array(
 ?>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
 <script>
+
+
+
+
+var request = new XMLHttpRequest();
+request.open('GET', '/pathways/status/<?= $pathway->id ?>', true);
+
+request.onload = function() {
+  if (this.status >= 200 && this.status < 400) {
+    // Success!
+    var data = JSON.parse(this.response);
+	console.log(data.percentages);
+  } else {
+    // We reached our target server, but it returned an error
+
+  }
+};
+
+request.onerror = function() {
+  // There was a connection error of some sort
+};
+request.send();
+
+
 var ctx = document.getElementById('myChart').getContext('2d');
 var data = {
     datasets: [
@@ -765,6 +789,7 @@ var myDoughnutChart = new Chart(ctx, {
 });
 
 
+	
 </script>
 
 

--- a/templates/Users/home.php
+++ b/templates/Users/home.php
@@ -15,10 +15,33 @@
 <div class="card-columns">
 	<?php foreach ($user->pathways as $pathways) : ?>
 	<div class="card p-3">
-	<div><?= $pathways->has('category') ? $this->Html->link($pathways->category->name, ['controller' => 'Categories', 'action' => 'view', $pathways->category->id]) : '' ?></div>
-	<h2><?= $this->Html->link($pathways->name, ['controller' => 'Pathways', 'action' => 'view', $pathways->id]) ?></h2>
-	<div><?= h($pathways->description) ?></div>
+		<div><?= $pathways->has('category') ? $this->Html->link($pathways->category->name, ['controller' => 'Categories', 'action' => 'view', $pathways->category->id]) : '' ?></div>
+		<h2><?= $this->Html->link($pathways->name, ['controller' => 'Pathways', 'action' => 'view', $pathways->id]) ?></h2>
+		<div><?= h($pathways->description) ?></div>
+		<div class="status<?= $pathways->id ?>"></div>
 
+		<script>
+			var request<?= $pathways->id ?> = new XMLHttpRequest();
+
+			request<?= $pathways->id ?>.open('GET', '/pathways/status/<?= $pathways->id ?>', true);
+
+			request<?= $pathways->id ?>.onload = function() {
+			if (this.status >= 200 && this.status < 400) {
+				// Success!
+				var data<?= $pathways->id ?> = JSON.parse(this.response);
+				document.querySelector('.status<?= $pathways->id ?>').innerHTML = data<?= $pathways->id ?>.status;
+				console.log(data<?= $pathways->id ?>);
+			} else {
+				// We reached our target server, but it returned an error
+
+			}
+			};
+
+			request<?= $pathways->id ?>.onerror = function() {
+			// There was a connection error of some sort
+			};
+			request<?= $pathways->id ?>.send();
+		</script>
 	</div>
 	<?php endforeach; ?>
 </div>

--- a/templates/Users/home.php
+++ b/templates/Users/home.php
@@ -19,7 +19,6 @@
 		<h2><?= $this->Html->link($pathways->name, ['controller' => 'Pathways', 'action' => 'view', $pathways->id]) ?></h2>
 		<div><?= h($pathways->description) ?></div>
 		<div class="status<?= $pathways->id ?>"></div>
-
 		<script>
 			var request<?= $pathways->id ?> = new XMLHttpRequest();
 
@@ -38,7 +37,8 @@
 			};
 
 			request<?= $pathways->id ?>.onerror = function() {
-			// There was a connection error of some sort
+				// There was a connection error of some sort
+				document.querySelector('.status<?= $pathways->id ?>').innerHTML = 'Could not get status';
 			};
 			request<?= $pathways->id ?>.send();
 		</script>

--- a/templates/Users/home.php
+++ b/templates/Users/home.php
@@ -18,7 +18,7 @@
 	<div><?= $pathways->has('category') ? $this->Html->link($pathways->category->name, ['controller' => 'Categories', 'action' => 'view', $pathways->category->id]) : '' ?></div>
 	<h2><?= $this->Html->link($pathways->name, ['controller' => 'Pathways', 'action' => 'view', $pathways->id]) ?></h2>
 	<div><?= h($pathways->description) ?></div>
-	<img src="/img/activity-rings-mock.png">
+
 	</div>
 	<?php endforeach; ?>
 </div>

--- a/templates/Users/home.php
+++ b/templates/Users/home.php
@@ -4,6 +4,7 @@
  * @var \App\Model\Entity\User $user
 */
 ?>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
 <div class="btn-group float-right">
 <?= $this->Html->link(__('Logout'), ['action' => 'logout', $user->id], ['class' => 'btn btn-dark btn-sm']) ?>
 <?php //$this->Html->link(__('Edit User'), ['action' => 'edit', $user->id], ['class' => 'btn btn-dark btn-sm']) ?>
@@ -19,6 +20,7 @@
 		<h2><?= $this->Html->link($pathways->name, ['controller' => 'Pathways', 'action' => 'view', $pathways->id]) ?></h2>
 		<div><?= h($pathways->description) ?></div>
 		<div class="status<?= $pathways->id ?>"></div>
+		<canvas id="chart<?= $pathways->id ?>" width="400" height="400"></canvas>
 		<script>
 			var request<?= $pathways->id ?> = new XMLHttpRequest();
 
@@ -29,7 +31,17 @@
 				// Success!
 				var data<?= $pathways->id ?> = JSON.parse(this.response);
 				document.querySelector('.status<?= $pathways->id ?>').innerHTML = data<?= $pathways->id ?>.status;
-				console.log(data<?= $pathways->id ?>);
+				var ctx<?= $pathways->id ?> = document.getElementById('chart<?= $pathways->id ?>').getContext('2d');
+				var myDoughnutChart = new Chart(ctx<?= $pathways->id ?>, {
+					type: 'doughnut',
+					data: JSON.parse(data<?= $pathways->id ?>.chartjs),
+					options: { 
+						legend: { 
+							display: false 
+						},
+					}
+				});
+				//console.log(data<?= $pathways->id ?>);
 			} else {
 				// We reached our target server, but it returned an error
 

--- a/templates/Users/home.php
+++ b/templates/Users/home.php
@@ -41,7 +41,6 @@
 						},
 					}
 				});
-				//console.log(data<?= $pathways->id ?>);
 			} else {
 				// We reached our target server, but it returned an error
 

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -123,7 +123,7 @@ img {
 		<button class="btn btn-outline-dark my-2 my-sm-0" type="submit">Search</button>
 	</form>
 </nav>
-<div class="container-fluid" style="padding-bottom: 100px;">
+<div class="container" style="padding-bottom: 100px;">
 <div class="row justify-content-md-center">
 <div class="col">
 <?= $this->Flash->render() ?>

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -123,7 +123,7 @@ img {
 		<button class="btn btn-outline-dark my-2 my-sm-0" type="submit">Search</button>
 	</form>
 </nav>
-<div class="container" style="padding-bottom: 100px;">
+<div class="container-fluid" style="padding-bottom: 100px;">
 <div class="row justify-content-md-center">
 <div class="col">
 <?= $this->Flash->render() ?>
@@ -133,7 +133,7 @@ img {
 </div>
 <div class="container-fluid mt-3 bg-white" style="padding-top: 60px;">
 <div class="row mt-3">
-<div class="col-md-4 mt-3">
+<div class="col-md-5 mt-3">
 <div class="alert alert-light">
 <div><img src="/img/BCID_BCPSA_rgb_pos.jpg" width="400" alt="BC Public Service Agency logo"></div>
 <p>Your personal information is collected by the BC Public Service Agency in accordance with section 26(c) of the Freedom of Information and Protection of Privacy Act for the purposes of managing and administering employee development and training. If you have any questions, submit an AskMyHR request at www.gov.bc.ca/myhr/contact or call 250 952-6000.</p>

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -141,14 +141,7 @@ img {
 </div>
 </div>
 </div>
-<script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" 
-	integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" 
-	crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.0/js/bootstrap.min.js" 
-	integrity="sha384-3qaqj0lc6sV/qpzrc1N5DC6i1VRn/HyX4qdPaiEFbn54VjQBEU341pvjz7Dv3n6P" 
-	crossorigin="anonymous"></script>
-<script type="text/javascript" src="/js/bootstrap-multiselect.js"></script>
+
 <script>
 
 $(function () {


### PR DESCRIPTION
Got basic /pathways/status/id API working so that activity rings are loaded entirely via javascript. On pathway view, the rings are loaded via JS (currently vanillajs, but converting to jquery for project compatibility) and has a start and reloading the rings (but not the whole page) when a user claims an activity. On the user home page, each followed pathway has activity rings loaded. Note that this may need to be re-engineered if a user is following many pathways.