### PR TITLE
Ahaggett user autoadd

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -57,6 +57,7 @@ return [
         'webroot' => 'webroot',
         'wwwRoot' => WWW_ROOT,
         //'baseUrl' => env('SCRIPT_NAME'),
+        'useridir' => env('REMOTE_USER'),
         'fullBaseUrl' => false,
         'imageBaseUrl' => 'img/',
         'cssBaseUrl' => 'css/',

--- a/src/Application.php
+++ b/src/Application.php
@@ -122,19 +122,20 @@ class Application extends BaseApplication implements AuthorizationServiceProvide
     protected function configAuth(): \Authentication\AuthenticationService
     {
         $authenticationService = new \Authentication\AuthenticationService();
+        
         $authenticationService->setConfig([
             'unauthenticatedRedirect' => '/users/autoadd',
             'queryParam' => 'redirect',
         ]);
-
-        $authenticationService->loadAuthenticator('Authentication.Token', [
-            'queryParam' => 'idir'
-        ]);
-        
-         $authenticationService->loadIdentifier('Authentication.Token', [
-            'tokenField' => 'idir'
-            ]
-        );
+        // The Idir authenticator is currently just a stripped down version 
+        // of the token authenticator, and is in the 
+        // vendor\cakephp\authentication\src\Authenticator and 
+        // vendor\cakephp\authentication\src\Identified
+        // directories that are outside of version control at the moment
+        // #TODO figure out where to put these custom authenticator files
+        // so that they're part of the repo!
+        $authenticationService->loadAuthenticator('Authentication.Idir');
+        $authenticationService->loadIdentifier('Authentication.Idir');
 
         return $authenticationService;
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -122,18 +122,15 @@ class Application extends BaseApplication implements AuthorizationServiceProvide
     protected function configAuth(): \Authentication\AuthenticationService
     {
         $authenticationService = new \Authentication\AuthenticationService();
-        // $authenticationService->setConfig([
-        //     'unauthenticatedRedirect' => '/users/autoadd',
-        //     'queryParam' => 'redirect',
-        // ]);
-
-        //$authenticationService->loadAuthenticator('Authentication.Session');
-
-        $authenticationService->loadAuthenticator('Authentication.Token', [
-            'queryParam' => 'idir',
-            'header' => 'Authorization'
+        $authenticationService->setConfig([
+            'unauthenticatedRedirect' => '/users/autoadd',
+            'queryParam' => 'redirect',
         ]);
 
+        $authenticationService->loadAuthenticator('Authentication.Token', [
+            'queryParam' => 'idir'
+        ]);
+        
          $authenticationService->loadIdentifier('Authentication.Token', [
             'tokenField' => 'idir'
             ]

--- a/src/Application.php
+++ b/src/Application.php
@@ -62,12 +62,9 @@ class Application extends BaseApplication implements AuthorizationServiceProvide
         if (Configure::read('debug')) {
             $this->addPlugin('DebugKit');
         }
-
         // Load more plugins here
         $this->addPlugin('Authentication');
-	$this->addPlugin('Authorization');
-
-
+	    $this->addPlugin('Authorization');
     }
 
     /**
@@ -97,9 +94,9 @@ class Application extends BaseApplication implements AuthorizationServiceProvide
             ->add(new RoutingMiddleware($this))
             ->add(new \Authentication\Middleware\AuthenticationMiddleware($this->configAuth()));
 	
-	$middlewareQueue->add(new AuthorizationMiddleware($this));
+	    $middlewareQueue->add(new AuthorizationMiddleware($this));
         
-	return $middlewareQueue;
+	    return $middlewareQueue;
     }
 
     /**
@@ -122,41 +119,35 @@ class Application extends BaseApplication implements AuthorizationServiceProvide
         // Load more plugins here
     }
 
-protected function configAuth(): \Authentication\AuthenticationService
-{
-    $authenticationService = new \Authentication\AuthenticationService([
-        'unauthenticatedRedirect' => '/users/login',
-        'queryParam' => 'redirect',
-    ]);
+    protected function configAuth(): \Authentication\AuthenticationService
+    {
+        $authenticationService = new \Authentication\AuthenticationService();
+        // $authenticationService->setConfig([
+        //     'unauthenticatedRedirect' => '/users/autoadd',
+        //     'queryParam' => 'redirect',
+        // ]);
 
-    // Load identifiers, ensure we check email and password fields
-    $authenticationService->loadIdentifier('Authentication.Password', [
-        'fields' => [
-            'username' => 'idir',
-            'password' => 'password',
-        ]
-    ]);
+        //$authenticationService->loadAuthenticator('Authentication.Session');
 
-    // Load the authenticators, you want session first
-    $authenticationService->loadAuthenticator('Authentication.Session');
-    // Configure form data check to pick email and password
-    $authenticationService->loadAuthenticator('Authentication.Form', [
-        'fields' => [
-            'username' => 'idir',
-            'password' => 'password',
-        ],
-        'loginUrl' => '/users/login',
-    ]);
+        $authenticationService->loadAuthenticator('Authentication.Token', [
+            'queryParam' => 'idir',
+            'header' => 'Authorization'
+        ]);
 
-    return $authenticationService;
-}
+         $authenticationService->loadIdentifier('Authentication.Token', [
+            'tokenField' => 'idir'
+            ]
+        );
 
-public function getAuthorizationService(ServerRequestInterface $request): AuthorizationServiceInterface
-{
-    $resolver = new OrmResolver();
+        return $authenticationService;
+    }
 
-    return new AuthorizationService($resolver);
-}
+    public function getAuthorizationService(ServerRequestInterface $request): AuthorizationServiceInterface
+    {
+        $resolver = new OrmResolver();
+
+        return new AuthorizationService($resolver);
+    }
 
 
 }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -53,16 +53,16 @@ class AppController extends Controller
 
         $this->loadComponent('Authentication.Authentication');
 	
-	$this->loadComponent('Authorization.Authorization');
+        $this->loadComponent('Authorization.Authorization');
 
-	$active = $this->request->getAttribute('authentication')->getIdentity();
-	
-	$at = TableRegistry::getTableLocator()->get('ActivityTypes');
-	$atype = $at->find('all');
-	$atypes = $atype->toList();
+        $active = $this->request->getAttribute('authentication')->getIdentity();
+        
+        $at = TableRegistry::getTableLocator()->get('ActivityTypes');
+        $atype = $at->find('all');
+        $atypes = $atype->toList();
 
-	$this->set(compact('active','atypes'));
-        //$this->loadComponent('Authorization.Authorization');
+        $this->set(compact('active','atypes'));
+        
 
     }
 

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -58,10 +58,11 @@ class UsersController extends AppController
 
     /**
      * User auto-add method.
+     * 
      * This is the controller that we redirect to when we detect a user who
      * doesn't already have an account; in other words, they've gone through the
      * SiteMinder authentication already, there's a valid REMOTE_USER environment
-     * variable set, but it doesn't match anything in the system yet. All we do 
+     * variable set, but it doesn't match a user in the system. All we do 
      * is create a new user with the IDIR field set to the REMOTE_USER and then
      * redirect to the users/home page.
      * #TODO this should have a LDAP/GAL lookup to grab the user's name and email 

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -48,6 +48,40 @@ class UsersController extends AppController
         $this->set('user', $user);
     }
 
+
+    /**
+     * User auto add method
+     * This is the main controller that we redirect to when we detect a user who is
+     * not logged in, and doesn't already have an account.
+     *
+     * @return \Cake\Http\Response|null Redirects on successful add, throws error on fail
+     */
+    public function autoadd()
+    {
+        $this->Authorization->skipAuthorization();
+        $user = $this->Users->newEmptyEntity();
+        $user->createdby_id = 1;
+        $user->modifiedby_id = 1;
+        $user->ministry_id = 1;
+        $user->role_id = 1;
+        $user->name = 'Martin';
+        $user->idir = 'martinking';
+        $user->email = 'martinking@gov.bc.ca';
+        $user->password = 'martinking';
+    
+        $user = $this->Users->patchEntity($user, $user);
+        if ($this->Users->save($user)) {
+            print 'Ya good.';
+            //$this->Flash->success(__('The user has been saved.'));
+            //return $this->redirect(['action' => 'home']);
+        }
+        print 'Ya bad.';
+        //$this->Flash->error(__('The user could not be saved. Please, try again.'));
+
+    }
+
+
+
     /**
      * Add method
      *
@@ -125,47 +159,69 @@ class UsersController extends AppController
         return $this->redirect(['action' => 'index']);
     }
 
+    /**
+     * Login method
+     *
+     * @param 
+     * @return \Cake\Http\Response|null Redirects to user home page.
+     * @throws 
+     */
+    public function login() 
+    {
 
-public function login() 
-{
+        $this->Authorization->skipAuthorization();
+        $this->request->allowMethod(['get', 'post']);
+        $result = $this->Authentication->getResult();
+        // regardless of POST or GET, redirect if user is logged in
+        if ($result->isValid()) {
+            // redirect to /pages/home after login success
+            $redirect = $this->request->getQuery('redirect', [
+                'controller' => 'Users',
+                'action' => 'home',
+            ]);
 
-    $this->Authorization->skipAuthorization();
-    $this->request->allowMethod(['get', 'post']);
-    $result = $this->Authentication->getResult();
-    // regardless of POST or GET, redirect if user is logged in
-    if ($result->isValid()) {
-        // redirect to /pages/home after login success
-        $redirect = $this->request->getQuery('redirect', [
-            'controller' => 'Users',
-            'action' => 'home',
-        ]);
-
-        return $this->redirect($redirect);
+            return $this->redirect($redirect);
+        }
+        // display error if user submitted and authentication failed
+        if ($this->request->is('post') && !$result->isValid()) {
+            $this->Flash->error(__('Invalid username'));
+        }
     }
-    // display error if user submitted and authentication failed
-    if ($this->request->is('post') && !$result->isValid()) {
-        $this->Flash->error(__('Invalid username or password'));
-    }
-}
 
-public function logout()
-{
+    /**
+     * Logout method
+     *
+     * @param 
+     * @return \Cake\Http\Response|null Redirects to login page.
+     * @throws 
+     */
+    public function logout()
+    {
 
-    $this->Authorization->skipAuthorization();
-    $result = $this->Authentication->getResult();
-    // regardless of POST or GET, redirect if user is logged in
-    if ($result->isValid()) {
-        $this->Authentication->logout();
-        return $this->redirect(['controller' => 'Users', 'action' => 'login']);
+        $this->Authorization->skipAuthorization();
+        $result = $this->Authentication->getResult();
+        // regardless of POST or GET, redirect if user is logged in
+        if ($result->isValid()) {
+            $this->Authentication->logout();
+            return $this->redirect(['controller' => 'Users', 'action' => 'login']);
+        }
     }
-}
-public function beforeFilter(\Cake\Event\EventInterface $event)
-{
-    parent::beforeFilter($event);
-    // configure the login action to don't require authentication, preventing
-    // the infinite redirect loop issue
-    $this->Authentication->addUnauthenticatedActions(['login']);
-}
+
+    /**
+     * beforeFilter method
+     *
+     * @param string|null \Cake\Event\EventInterface $event.
+     * @return 
+     * @throws 
+     */
+    public function beforeFilter(\Cake\Event\EventInterface $event)
+    {
+        parent::beforeFilter($event);
+        // configure the login action to don't require authentication, preventing
+        // the infinite redirect loop issue
+        $this->Authentication->addUnauthenticatedActions(['login']);
+    }
+
    /**
      * Home method
      *

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -91,11 +91,8 @@ class UsersController extends AppController
         } else {
             echo 'Something went wrong when creating your account. Please contact learningagent@gov.bc.ca for assistance.';
         }
-        
 
     }
-
-
 
     /**
      * Add method

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -76,20 +76,20 @@ class UsersController extends AppController
      */
     public function autoadd()
     {
-        $this->request->allowMethod(['get']);
         $this->Authorization->skipAuthorization();
         $user = $this->Users->newEmptyEntity();
-        $user->name = 'Learner';
-        $user->idir = env('REMOTE_USER');
+        $idir = env('REMOTE_USER');
+        $user->name = $idir;
+        $user->idir = $idir;
         $user->ministry_id = 1;
         $user->role_id = 1;
-        $user->email = 'learner@gov.bc.ca';
+        $user->email = $idir . '@gov.bc.ca';
         $user->password = 'learning';
 
         if ($this->Users->save($user)) {
             return $this->redirect(['action' => 'home']);
         } else {
-            $this->Flash->error(__('Something went wrong when creating your account. Please contact learningagent@gov.bc.ca for assistance.'));
+            echo 'Something went wrong when creating your account. Please contact learningagent@gov.bc.ca for assistance.';
         }
         
 

--- a/src/Policy/UserPolicy.php
+++ b/src/Policy/UserPolicy.php
@@ -117,6 +117,11 @@ class UserPolicy
         //return $user->getIdentifier('role_id') === 5;
         return $user->role_id === 5;
     }
+    protected function isCurator(IdentityInterface $user, User $resource)
+    {
+        //return $user->getIdentifier('role_id') === 5;
+        return $user->role_id === 2;
+    }
 
 
 

--- a/templates/Users/autoadd.php
+++ b/templates/Users/autoadd.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \App\Model\Entity\User $user
+*/
+?>

--- a/templates/Users/home.php
+++ b/templates/Users/home.php
@@ -5,13 +5,7 @@
 */
 ?>
 
-<div class="btn-group float-right">
-<?= $this->Html->link(__('Logout'), ['action' => 'logout', $user->id], ['class' => 'btn btn-dark btn-sm']) ?>
-<?php //$this->Html->link(__('Edit User'), ['action' => 'edit', $user->id], ['class' => 'btn btn-dark btn-sm']) ?>
-<?php //$this->Form->postLink(__('Delete User'), ['action' => 'delete', $user->id], ['confirm' => __('Are you sure you want to delete # {0}?', $user->id), 'class' => 'btn btn-dark btn-sm']) ?>
-</div>
 <h1><?= h($user->name) ?></h1>
-
 <div class="row">
 <div class="col-md-6">
 <?php if (!empty($user->pathways)) : ?>
@@ -62,7 +56,8 @@
 	</div>
 	</div>
 	<?php endforeach; ?>
-
+<?php else: ?>
+<?= _('You\'re not following any pathways yet.') ?>
 <?php endif; ?>
 
 </div></div>
@@ -122,7 +117,8 @@ Sort:
 
 </div>
 </div>
-
+<?php else: ?>
+<?= _('You\'re not claimed any activities yet.') ?>
 <?php endif; ?>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>

--- a/templates/Users/home.php
+++ b/templates/Users/home.php
@@ -57,7 +57,7 @@
 	</div>
 	<?php endforeach; ?>
 <?php else: ?>
-<?= _('You\'re not following any pathways yet.') ?>
+<h1><?= _('You\'re not following any pathways yet.') ?></h1>
 <?php endif; ?>
 
 </div></div>
@@ -118,9 +118,19 @@ Sort:
 </div>
 </div>
 <?php else: ?>
-<?= _('You\'re not claimed any activities yet.') ?>
+<h1><?= _('You\'re not claimed any activities yet.') ?></h1>
 <?php endif; ?>
 
+<script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" 
+	integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" 
+	crossorigin="anonymous"></script>
+
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.0/js/bootstrap.min.js" 
+	integrity="sha384-3qaqj0lc6sV/qpzrc1N5DC6i1VRn/HyX4qdPaiEFbn54VjQBEU341pvjz7Dv3n6P" 
+	crossorigin="anonymous"></script>
+	
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>

--- a/templates/Users/login.php
+++ b/templates/Users/login.php
@@ -7,14 +7,10 @@
    
     <?= $this->Form->create() ?>
         <?= $this->Form->control('idir', ['required' => true, 'class' => 'form-control']) ?>
-        <?= $this->Form->control('password', ['required' => true, 'class' => 'form-control']) ?>
+        <?= $this->Flash->render() ?>
     <?= $this->Form->submit(__('IDIR Login'), ['class' => 'btn btn-dark btn-block mt-3']); ?>
     <?= $this->Form->end() ?>
 <p class="mt-3">When you log in, you can follow pathways and claim activities!</p>
-</div>
-</div>
-</div>
-
 </div>
 </div>
 </div>

--- a/webroot/info.php
+++ b/webroot/info.php
@@ -1,0 +1,1 @@
+<?php phpinfo() ?>


### PR DESCRIPTION
Previously we were relying on solo app account creation/management. With this pull, we're now almost ready for the production environment (at least for testing in prod) where the app will live behind SiteMinder, and folks will authenticate before they even hit the app. SiteMinder sets the IDIR as an environment variable; the app now checks if that IDIR matches anything in the agent's database; if it does, you're logged in automatically and you proceed; if it doesn't, then you're directed to the users/autoadd controller, which will create the entry in the users table and redirect for new authentication. Now that the account has been autoadd'ed, the new user is taken their new home page. They aren't asked for anything, they just have an account created automagically the first time they hit the app. NOTE: the new custom Authenticator and Identifier files are currently located in the vendor\cakephp\authenticator... folder structure which is outside of the repo (ignored). #TODO figure out where those files should live inside the repo!!